### PR TITLE
fix: Skip extraneous lines when parsing auto-test action

### DIFF
--- a/server/src/main/java/org/kiwi/console/generate/GeminiModel.java
+++ b/server/src/main/java/org/kiwi/console/generate/GeminiModel.java
@@ -38,7 +38,6 @@ public class GeminiModel implements Model {
                                 .includeThoughts(true)
                                 .build()
                 )
-                .maxOutputTokens(8192)
                 .build()));
     }
 

--- a/server/src/main/java/org/kiwi/console/generate/rest/AutoTestActionParser.java
+++ b/server/src/main/java/org/kiwi/console/generate/rest/AutoTestActionParser.java
@@ -1,26 +1,30 @@
 package org.kiwi.console.generate.rest;
 
-import org.kiwi.console.generate.AgentException;
+import lombok.extern.slf4j.Slf4j;
 import org.kiwi.console.generate.AutoTestActionType;
 
+import java.util.Objects;
+
+@Slf4j
 public class AutoTestActionParser {
 
     public static AutoTestAction parse(String text) {
         var reader = new Reader(text);
-        if (reader.isEof())
-            throw new RuntimeException("Invalid action text: " + text);
-        var actionTypeStr = reader.readLine();
-        AutoTestActionType type;
-        try {
-            type = AutoTestActionType.valueOf(actionTypeStr.toUpperCase());
-        } catch (Exception e) {
-            throw new AgentException("Invalid action type: " + actionTypeStr);
+        AutoTestActionType type = null;
+        while (!reader.isEof()) {
+            var line = reader.readLine();
+            try {
+                type = AutoTestActionType.valueOf(line.trim().toUpperCase());
+                break;
+            } catch (Exception e) {
+                log.warn("Skipping extraneous line: " + line);
+            }
         }
         if (reader.isEof())
             throw new RuntimeException("Invalid action text: " + text);
         var desc = reader.readLine();
-        var content =reader.readRemaining();
-        return new AutoTestAction(type, desc, content);
+        var content = reader.readRemaining();
+        return new AutoTestAction(Objects.requireNonNull(type), desc, content);
     }
 
     private static class Reader {


### PR DESCRIPTION
chore: Remove gemini max output tokens config