### PR TITLE
fix: add context-1m beta header to unlock 1M context

### DIFF
--- a/server/src/main/java/org/kiwi/console/generate/claude/ClaudeClient.java
+++ b/server/src/main/java/org/kiwi/console/generate/claude/ClaudeClient.java
@@ -69,7 +69,7 @@ public class ClaudeClient {
                     .header("Content-Type", "application/json")
                     .header("x-api-key", apiKey)
                     .header("anthropic-version", API_VERSION)
-                    .header("anthropic-beta", "interleaved-thinking-2025-05-14")
+                    .header("anthropic-beta", "interleaved-thinking-2025-05-14,context-1m-2025-08-07")
                     .header("Accept", "text/event-stream")
                     .header("Cache-Control", "no-cache")
                     .header("User-Agent", "Claude-Java-Client-OkHttp/1.0")


### PR DESCRIPTION
## Summary
- Add `context-1m-2025-08-07` beta header to `ClaudeClient` to unlock the 1M token context window for Claude Opus 4.6
- Fixes HTTP 400 "prompt is too long: 207213 tokens > 200000 maximum" error

## Test plan
- [ ] Verify prompts >200k tokens are accepted without error
- [ ] Verify normal-sized prompts still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)